### PR TITLE
Closes #3: Ignore random errors in certain cases

### DIFF
--- a/App/Admin/Notices.php
+++ b/App/Admin/Notices.php
@@ -7,10 +7,26 @@ namespace WP_Rocket_e2e\App\Admin;
  */
 class Notices {
 
+    /**
+     * Array of patterns to match WP Rocket related errors in debug.log.
+     *
+     * @var array
+     */
     private $debug_log_patterns = [
         '/plugins/wp-rocket/',
-        'wpr_rucss_used_css',
-        'wpr_rocket_cache',
+        'WP_Rocket',
+    ];
+
+    /**
+     * Array of WP Rocket related error patterns to exclude.
+     *
+     * @var array
+     */
+    private $debug_log_exclusion_patterns = [
+        'wp-rocket/inc/Dependencies/Database',
+        'WP_Rocket(.*)Table->create',
+        'wp-rocket/inc/Engine/Common/Database/Queries/AbstractQuery',
+        'Failed opening(.*?)wp-rocket/',
     ];
 
     /**
@@ -19,6 +35,8 @@ class Notices {
      * @return void
      */
     public function debug_log_notice() : void {
+        $display_error_notice = true;
+
         if ( ! defined( 'WP_DEBUG' ) || ! defined( 'WP_DEBUG_LOG' ) || false === WP_DEBUG || false === WP_DEBUG_LOG ) {
             return;
         }
@@ -30,9 +48,46 @@ class Notices {
         }
 
         $content = $file_system->get_contents( WP_CONTENT_DIR . '/debug.log' );
+        preg_match_all( '#^\[(?<timestamp>.*?)\] (?<error>.+?)(?=\n\[|\z)#ms', $content, $matches, PREG_SET_ORDER);
 
+        // Flag errors related to WP Rocket in log.
+        $wpr_related_errors = [];
         $patterns = implode( '|', $this->debug_log_patterns );
-        if ( ! preg_match( '#' . $patterns . '#', $content ) ) {
+
+        foreach( $matches as $match ) {
+            if ( ! preg_match( '#' . $patterns . '#', $match['error'] ) ) {
+                continue;
+            }
+
+            // Store errors.
+            $wpr_related_errors[] = $match['error'];
+        }
+
+        // Bail if no WP Rocket related error.
+        if ( empty( $wpr_related_errors ) ) {
+            return;
+        }
+       
+        /**
+         * Filters WP Rocket related errors to be excluded.
+         * 
+         * @param array $exclusion_patterns Array of WP Rocket related error patterns to exclude.
+         */
+        $exclusion_patterns = apply_filters( 'rocket_e2e_error_exclusions', $this->debug_log_exclusion_patterns );
+        $exclusion_patterns = implode( '|', $exclusion_patterns );
+
+        // Check if errors should be excluded from notice.
+        foreach( $wpr_related_errors as $errors ) {
+            if ( preg_match( '#' . $exclusion_patterns . '#', $errors ) ) {
+                $display_error_notice = false;
+
+                continue;
+            }
+
+            $display_error_notice = true;
+        }
+
+        if ( ! $display_error_notice ) {
             return;
         }
 

--- a/App/Admin/Notices.php
+++ b/App/Admin/Notices.php
@@ -74,6 +74,12 @@ class Notices {
          * @param array $exclusion_patterns Array of WP Rocket related error patterns to exclude.
          */
         $exclusion_patterns = apply_filters( 'rocket_e2e_error_exclusions', $this->debug_log_exclusion_patterns );
+
+        // Validate filter return.
+        if ( ! is_array( $exclusion_patterns ) || empty( $exclusion_patterns ) ) {
+            $exclusion_patterns =  $this->debug_log_exclusion_patterns;
+        }
+
         $exclusion_patterns = implode( '|', $exclusion_patterns );
 
         // Check if errors should be excluded from notice.


### PR DESCRIPTION
# Description

Fixes #3 
Introduces exclusions of known WP Rocket related errors in debug.log

## Type of change

- [x] Enhancement (non-breaking change which improves an existing functionality).

## Detailed scenario

Errors Identified [here](https://www.notion.so/wpmedia/List-of-possible-random-Errors-while-having-background-process-fffed22a22f080c4976cfdd4cc984e01) will be flagged in e2e with develop branch

## Technical description

### Documentation

Added an exclusion for known wpr related errors, gather all wpr related errors and filter based on matches, also new patterns can be added using filters.

Patterns used:
```
'wp-rocket/inc/Dependencies/Database',
'WP_Rocket(.*)Table->create',
'wp-rocket/inc/Engine/Common/Database/Queries/AbstractQuery',
'Failed opening(.*?)wp-rocket/',
```

### New dependencies

N/A

### Risks

New type of errors with patterns not already covered could surface, that's the reason the option for a filter is available to still work till new pattern is implemented.

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [ ] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [ ] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

- No test suite setup for this repo
- No entry points to protect
- No user error to handle
