### PR TITLE
exclude already exists error from debug.log

### DIFF
--- a/App/Admin/Notices.php
+++ b/App/Admin/Notices.php
@@ -32,7 +32,12 @@ class Notices {
         $content = $file_system->get_contents( WP_CONTENT_DIR . '/debug.log' );
 
         $patterns = implode( '|', $this->debug_log_patterns );
-        if ( ! preg_match( '#' . $patterns . '#', $content ) ) {
+        $lines = array_filter(
+            explode( "\n", $content ),
+            fn( $line ) => preg_match( '#' . $patterns . '#', $line ) && ! str_contains( $line, 'already exists' )
+        );
+
+        if ( empty( $lines ) ) {
             return;
         }
 


### PR DESCRIPTION
# Description
Done by discussion with Claude

Fixes https://github.com/wp-media/wp-rocket-e2e/issues/381

Sometimes tests failed due to table already exists error which is expected due to fast delete/install while having BG process

## Type of change

- [ ] New feature (non-breaking change which adds functionality).
- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] Enhancement (non-breaking change which improves an existing functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before).
- [ ] Sub-task of #(issue number)
- [ ] Chore
- [ ] Release

## Detailed scenario

### What was tested

- updated the helper file at test site with this PR  https://github.com/wp-media/wp-rocket-e2e/pull/382 and smoke test passed 
### How to test

- Use PR and run smoke at e2e , test pass

### Affected Features & Quality Assurance Scope

- This step "I must not see any error in debug.log" won't fail with this kind of error
```
[26-Jun-2026 11:18:50 UTC] WordPress database error Table 'wp_wpr_rucss_used_css' already exists for query CREATE TABLE wp_wpr_rucss_used_css ( 
				id               		bigint(20) unsigned NOT NULL AUTO_INCREMENT,
				url              		varchar(2000)       NOT NULL default '',
				css              		longtext                     default NULL,
				hash             		varchar(32)                  default '',
				error_code       		varchar(32)             NULL default NULL,
				error_message    		longtext                NULL default NULL,
				unprocessedcss   		longtext                NULL,
				retries          		tinyint(1)          NOT NULL default 1,
				is_mobile        		tinyint(1)          NOT NULL default 0,
				job_id           		varchar(255)        NOT NULL default '',
				queue_name       		varchar(255)        NOT NULL default '',
				status           		varchar(255)        NOT NULL default '',
				modified         		timestamp           NOT NULL default '0000-00-00 00:00:00',
				last_accessed    		timestamp           NOT NULL default '0000-00-00 00:00:00',
				submitted_at     		timestamp           NULL,
				next_retry_time     	timestamp           NOT NULL default '0000-00-00 00:00:00',
				PRIMARY KEY (id),
				KEY url (url(150), is_mobile),
				KEY modified (modified),
				KEY last_accessed (last_accessed),
				INDEX `status_index` (`status`(191)),
				INDEX `error_code_index` (`error_code`(32)),
				KEY hash (hash) ) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_520_ci made by require('wp-blog-header.php'), require_once('wp-load.php'), require_once('wp-config.php'), require_once('wp-settings.php'), do_action('init'), WP_Hook->do_action, WP_Hook->apply_filters, WP_Rocket\Dependencies\BerlinDB\Database\Table->maybe_upgrade, WP_Rocket\Dependencies\BerlinDB\Database\Table->install, WP_Rocket\Dependencies\BerlinDB\Database\Table->create
```
## Technical description

### Documentation

- We exclude the error containing already exist

### New dependencies

N/A

### Risks

- If for any reason, error like that happened for real , it will be missed

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [ ] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [ ] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

N/A
# Additional Checks
- [ ] In the case of complex code, I wrote comments to explain it.
- [ ] When possible, I prepared ways to observe the implemented system (logs, data, etc.).
- [ ] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)
