### PR TITLE
enhancement to check that cache isnot regenerated with admin refresh

### DIFF
--- a/App/Activation_Deactivation.php
+++ b/App/Activation_Deactivation.php
@@ -36,6 +36,8 @@ class Activation_Deactivation {
         }
         
         update_option( CONFIG['PLUGIN_OPTION'], $existing_config );
+
+        delete_option( 'rocket_e2e_homepage_cache_mtime' );
     }
 
     /**
@@ -45,5 +47,6 @@ class Activation_Deactivation {
      */
     public function deactivate() : void {
         delete_option( CONFIG['PLUGIN_OPTION'] );
+        delete_option( 'rocket_e2e_homepage_cache_mtime' );
     }
 }

--- a/App/Admin/Pages.php
+++ b/App/Admin/Pages.php
@@ -94,6 +94,17 @@ class Pages {
             ],
             $this->cache->is_common_cache_dir_used_for_users()
         );
+
+        $this->template->add_test_case(
+            'cache',
+            'should_not_regenerate_cache_on_admin_refresh',
+            'Should not regenerate homepage cache after an admin refresh',
+            [
+                'text' => 'Visit this tab, refresh wpr admin, then revisit this tab to compare',
+                'type' => 'info',
+            ],
+            $this->cache->is_cache_preserved()
+        );
     }
 
     private function tools_view() : void {

--- a/App/Admin/Pages.php
+++ b/App/Admin/Pages.php
@@ -95,15 +95,32 @@ class Pages {
             $this->cache->is_common_cache_dir_used_for_users()
         );
 
+        $cache_preservation_state = $this->cache->get_cache_preservation_state();
+        $cache_preservation_notes = [
+            Cache::CACHE_NOT_STARTED => [
+                'text' => 'Not started',
+                'type' => 'info',
+            ],
+            Cache::CACHE_NOT_YET_COMPARED => [
+                'text' => 'Cached',
+                'type' => 'info',
+            ],
+            Cache::CACHE_PRESERVED => [
+                'text' => 'Homepage cache was preserved',
+                'type' => 'success',
+            ],
+            Cache::CACHE_REGENERATED => [
+                'text' => 'Homepage cache was regenerated',
+                'type' => 'danger',
+            ],
+        ];
+
         $this->template->add_test_case(
             'cache',
             'should_not_regenerate_cache_on_admin_refresh',
             'Should not regenerate homepage cache after an admin refresh',
-            [
-                'text' => 'Visit this tab, refresh wpr admin, then revisit this tab to compare',
-                'type' => 'info',
-            ],
-            $this->cache->is_cache_preserved()
+            $cache_preservation_notes[ $cache_preservation_state ],
+            $cache_preservation_state
         );
     }
 

--- a/App/Modules/Cache/Cache.php
+++ b/App/Modules/Cache/Cache.php
@@ -5,6 +5,36 @@ namespace WP_Rocket_e2e\App\Modules\Cache;
 class Cache {
 
     /**
+     * No cache file exists yet.
+     */
+    const CACHE_NOT_STARTED = 'not_started';
+
+    /**
+     * A baseline was just recorded (or the previous baseline was just consumed by this call);
+     * nothing has been compared against it yet.
+     */
+    const CACHE_NOT_YET_COMPARED = 'not_yet_compared';
+
+    /**
+     * Cache file's mtime matched the recorded baseline.
+     */
+    const CACHE_PRESERVED = 'preserved';
+
+    /**
+     * Cache file's mtime differed from the recorded baseline.
+     */
+    const CACHE_REGENERATED = 'regenerated';
+
+    /**
+     * Homepage cache file's mtime as captured at the start of the current request, before
+     * any admin-side hook (e.g. admin_init) has had a chance to clear it. False if no cache
+     * file existed at that point. Null until capture_request_start_snapshot() has run.
+     *
+     * @var int|false|null
+     */
+    private static $request_start_mtime = null;
+
+    /**
      * Cache tests paths.
      *
      * @var array Array of url paths to be tested against.
@@ -129,37 +159,84 @@ class Cache {
     }
 
     /**
-     * Check that the homepage cache file was not regenerated (cleared) between two calls.
+     * Snapshot the homepage cache file's mtime as early in the request as possible.
      *
-     * The first call records the cache file's current mtime as a baseline and returns true.
-     * A subsequent call compares the current mtime against that baseline, clears it, and
-     * returns whether the file is unchanged.
+     * Must run on a hook that fires before any admin-side clearing (e.g. 'init', which
+     * always completes before 'admin_init'). Without this, checking the file at render
+     * time (inside the admin page callback) would run *after* the same request's own
+     * admin_init has already had a chance to clear the cache, making it impossible to
+     * ever observe an unmolested "before" state on a site where the bug fires on every
+     * admin request.
      *
-     * @return boolean
+     * Idempotent: only the first call in a given request actually captures anything.
+     *
+     * @return void
      */
-    public function is_cache_preserved() : bool {
+    public function capture_request_start_snapshot() : void {
+        if ( null !== self::$request_start_mtime ) {
+            return;
+        }
+
         if ( ! is_wpr_active() ) {
-            return false;
+            self::$request_start_mtime = false;
+            return;
         }
 
         $cache_file = $this->get_homepage_cache_file();
 
-        if ( ! $cache_file ) {
-            return false;
+        self::$request_start_mtime = $cache_file ? rocket_e2e_direct_filesystem()->mtime( $cache_file ) : false;
+    }
+
+    /**
+     * Check whether the homepage cache file was preserved (not regenerated) between two calls.
+     *
+     * A call with no cache file yet returns self::CACHE_NOT_STARTED. A call with no recorded
+     * baseline (or right after the previous baseline was consumed) records the request-start
+     * mtime and returns self::CACHE_NOT_YET_COMPARED, since nothing has been compared yet. The
+     * following call compares that request's start mtime against the recorded baseline, clears
+     * it, and returns self::CACHE_PRESERVED or self::CACHE_REGENERATED.
+     *
+     * Relies on capture_request_start_snapshot() having already run this request (see
+     * Cache\Subscriber, hooked on 'init') so the mtime reflects the state before this
+     * request's own admin_init could have cleared it.
+     *
+     * @return string One of self::CACHE_NOT_STARTED, self::CACHE_NOT_YET_COMPARED, self::CACHE_PRESERVED, self::CACHE_REGENERATED.
+     */
+    public function get_cache_preservation_state() : string {
+        if ( ! is_wpr_active() ) {
+            return self::CACHE_NOT_STARTED;
         }
 
-        $current_mtime = rocket_e2e_direct_filesystem()->mtime( $cache_file );
+        $this->capture_request_start_snapshot();
 
-        $recorded_mtime = get_transient( 'rocket_e2e_homepage_cache_mtime' );
+        $current_mtime = self::$request_start_mtime;
+        $recorded_mtime = get_option( 'rocket_e2e_homepage_cache_mtime', false );
 
+        // No baseline recorded yet: record one now, if there's a file to measure.
+        //
+        // A plain option is used instead of a transient because WP Rocket's cache-clearing
+        // routine calls wp_cache_flush(), and on sites with a persistent object cache,
+        // transients are stored only in the object cache (never written to wp_options) —
+        // so the very clear we're testing for would silently wipe a transient-based baseline
+        // before it could ever be compared. Options always write through to the DB.
         if ( false === $recorded_mtime ) {
-            set_transient( 'rocket_e2e_homepage_cache_mtime', $current_mtime, HOUR_IN_SECONDS );
-            return true;
+            if ( false === $current_mtime ) {
+                return self::CACHE_NOT_STARTED;
+            }
+
+            update_option( 'rocket_e2e_homepage_cache_mtime', $current_mtime, false );
+            return self::CACHE_NOT_YET_COMPARED;
         }
 
-        delete_transient( 'rocket_e2e_homepage_cache_mtime' );
+        // A baseline exists: this call consumes it, one way or another.
+        delete_option( 'rocket_e2e_homepage_cache_mtime' );
 
-        return (int) $recorded_mtime === (int) $current_mtime;
+        // The file having vanished entirely is itself proof the cache was cleared.
+        if ( false === $current_mtime ) {
+            return self::CACHE_REGENERATED;
+        }
+
+        return (int) $recorded_mtime === (int) $current_mtime ? self::CACHE_PRESERVED : self::CACHE_REGENERATED;
     }
 
     /**

--- a/App/Modules/Cache/Cache.php
+++ b/App/Modules/Cache/Cache.php
@@ -129,6 +129,60 @@ class Cache {
     }
 
     /**
+     * Check that the homepage cache file was not regenerated (cleared) between two calls.
+     *
+     * The first call records the cache file's current mtime as a baseline and returns true.
+     * A subsequent call compares the current mtime against that baseline, clears it, and
+     * returns whether the file is unchanged.
+     *
+     * @return boolean
+     */
+    public function is_cache_preserved() : bool {
+        if ( ! is_wpr_active() ) {
+            return false;
+        }
+
+        $cache_file = $this->get_homepage_cache_file();
+
+        if ( ! $cache_file ) {
+            return false;
+        }
+
+        $current_mtime = rocket_e2e_direct_filesystem()->mtime( $cache_file );
+
+        $recorded_mtime = get_transient( 'rocket_e2e_homepage_cache_mtime' );
+
+        if ( false === $recorded_mtime ) {
+            set_transient( 'rocket_e2e_homepage_cache_mtime', $current_mtime, HOUR_IN_SECONDS );
+            return true;
+        }
+
+        delete_transient( 'rocket_e2e_homepage_cache_mtime' );
+
+        return (int) $recorded_mtime === (int) $current_mtime;
+    }
+
+    /**
+     * Locate the homepage cache file, http or https variant.
+     *
+     * @return string|false
+     */
+    private function get_homepage_cache_file() {
+        $file_system = rocket_e2e_direct_filesystem();
+        $cache_dir = $this->get_cache_root_dir();
+
+        foreach ( [ 'index.html', 'index-https.html' ] as $filename ) {
+            $path = $cache_dir . '/' . $filename;
+
+            if ( $file_system->exists( $path ) ) {
+                return $path;
+            }
+        }
+
+        return false;
+    }
+
+    /**
      * Return root cache directory.
      *
      * @param boolean $user_cache True if test case is user cache.

--- a/App/Modules/Cache/Subscriber.php
+++ b/App/Modules/Cache/Subscriber.php
@@ -10,6 +10,23 @@ use WP_Rocket_e2e\Events\Subscriber_Interface;
 class Subscriber implements Subscriber_Interface {
 
     /**
+     * Cache instance.
+     *
+     * @var Cache
+     */
+    private $cache;
+
+    /**
+     * Instantiate class.
+     *
+     * @param Cache $cache Cache instance.
+     * @return void
+     */
+    public function __construct( Cache $cache ) {
+        $this->cache = $cache;
+    }
+
+    /**
      * Returns array of events this listens to.
      *
      * @return array
@@ -23,7 +40,17 @@ class Subscriber implements Subscriber_Interface {
             'transient_wp_rocket_customer_data' => [ 'transient_wp_rocket_customer_data_license_override', 11 ],
             'pre_get_rocket_option_consumer_key' => 'pre_get_rocket_option_consumer_key',
             'pre_get_rocket_option_consumer_email' => 'pre_get_rocket_option_consumer_email',
+            'init' => 'capture_cache_snapshot',
         ];
+    }
+
+    /**
+     * Snapshot the homepage cache file's mtime before any admin-side hook can clear it.
+     *
+     * @return void
+     */
+    public function capture_cache_snapshot() : void {
+        $this->cache->capture_request_start_snapshot();
     }
 
     /**

--- a/App/Modules/ServiceProvider.php
+++ b/App/Modules/ServiceProvider.php
@@ -15,12 +15,13 @@ class ServiceProvider extends AbstractServiceProvider {
         $services = [
             'cache_subscriber',
         ];
-        
+
         return in_array( $id, $services );
     }
 
     public function register() : void
     {
-        $this->getContainer()->add( 'cache_subscriber', CacheSubscriber::class );
+        $this->getContainer()->add( 'cache_subscriber', CacheSubscriber::class )
+        ->addArgument( $this->getContainer()->get( 'cache' ) );
     }
 }

--- a/README.md
+++ b/README.md
@@ -88,6 +88,24 @@ Cache presence is checked against two default test paths:
 
 These paths can be overridden using the `rocket_e2e_cache_test_paths` filter (see [Hooks](#hooks) below).
 
+#### Homepage cache preservation (`should_not_regenerate_cache_on_admin_refresh`)
+
+Unlike the test cases above, `should_not_regenerate_cache_on_admin_refresh` does **not** render a
+`true`/`false` result. It tracks a multi-step state across successive admin page loads by
+comparing the homepage cache file's mtime between requests, so its `#should_not_regenerate_cache_on_admin_refresh`
+element renders one of four fixed strings:
+
+| Rendered text | Meaning |
+|---|---|
+| `Not Started` | No homepage cache file exists yet — nothing to track. |
+| `Not Yet Compared` | A baseline mtime was just recorded on this request; the next admin page load will compare against it. |
+| `Preserved` | The homepage cache file's mtime was unchanged since the baseline — cache was **not** regenerated. |
+| `Regenerated` | The homepage cache file's mtime changed (or the file is gone) since the baseline — cache **was** regenerated. |
+
+Because the check requires two successive admin page loads (one to record the baseline, one to
+compare), a Playwright test must read this element at least twice, reloading the admin page in
+between, before `Preserved`/`Regenerated` can appear.
+
 ---
 
 ### Filter Simulation
@@ -203,6 +221,23 @@ Navigate to the helper plugin admin page and query element IDs that correspond t
 // Example: check cache generation for logged-in users
 const result = await page.locator('#should_generate_cache_files_for_logged-in_users').textContent();
 expect(result).toBe('Returned True');
+```
+
+`should_not_regenerate_cache_on_admin_refresh` reads as one of `Not Started`, `Not Yet Compared`,
+`Preserved`, or `Regenerated` instead — see [Homepage cache preservation](#homepage-cache-preservation-should_not_regenerate_cache_on_admin_refresh):
+
+```js
+// First load: records the baseline mtime.
+await page.goto('/wp-admin/tools.php?page=rocket_e2e_tests_helper');
+let result = await page.locator('#should_not_regenerate_cache_on_admin_refresh').textContent();
+expect(result).toBe('Not Yet Compared');
+
+// ... perform the admin refresh under test here ...
+
+// Second load: compares against the recorded baseline.
+await page.reload();
+result = await page.locator('#should_not_regenerate_cache_on_admin_refresh').textContent();
+expect(result).toBe('Preserved'); // or 'Regenerated' if the bug reproduces
 ```
 
 ### 2. Setting filter simulation values

--- a/views/modules/cache.php
+++ b/views/modules/cache.php
@@ -17,7 +17,13 @@ defined( 'ABSPATH' ) || exit;
           <?php endif; ?>
         </div>
         <small class="d-inline-flex px-2 py-1 fw-semibold text-success-emphasis bg-primary-subtle border border-primary-subtle rounded-2" id="<?php echo esc_attr( $test_case_id ) ?>">
-            <?php echo $test_case['result'] ? 'Returned True' : 'Returned False';  ?>
+            <?php
+            if ( is_bool( $test_case['result'] ) ) {
+                echo $test_case['result'] ? 'Returned True' : 'Returned False';
+            } else {
+                echo esc_html( ucwords( str_replace( '_', ' ', (string) $test_case['result'] ) ) );
+            }
+            ?>
         </small>
       </div>
     </div>


### PR DESCRIPTION
# Description
Generated by AI after discussion

Fixes https://github.com/wp-media/wp-rocket-e2e/issues/383
This PR to move the check on cache cleared for home to helper instead of e2e

## Type of change

- [ ] New feature (non-breaking change which adds functionality).
- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] Enhancement (non-breaking change which improves an existing functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before).
- [ ] Sub-task of #(issue number)
- [ ] Chore
- [ ] Release

## Detailed scenario

### What was tested

- Use WPR zip that has the bug , return false for shouldn't regenerate cache
- Use WPR zip with fix, return true for shouldn't regenerate cache

### How to test

As mentioned above

### Affected Features & Quality Assurance Scope

- Confirm that cache wasnot regenerated where needed (now it's about home page cache, could be enhanced to be on any page)

## Technical description

### Documentation
Changes made in wp-rocket-e2e-test-helper:

1- [Cache.php](vscode-webview://0nikvrlc6s5bm54c9ao0sjlonsjsoljtmcdtvr7ne9fq5t9v7tcr/wp-rocket-e2e-test-helper/App/Modules/Cache/Cache.php#L131-L179) — added is_cache_preserved() and private helper get_homepage_cache_file(). First call locates the real homepage cache file (index.html/index-https.html), records its mtime in a transient, returns true. Next call compares current mtime to the recorded one, clears the transient, returns true only if unchanged.
2- [Pages.php](vscode-webview://0nikvrlc6s5bm54c9ao0sjlonsjsoljtmcdtvr7ne9fq5t9v7tcr/wp-rocket-e2e-test-helper/App/Admin/Pages.php#L98-L106) — registered it as a new test case should_not_regenerate_cache_on_admin_refresh on the Cache tab, so it renders as a card exactly like the existing checks.

### New dependencies

N/A
### Risks

N/A
# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I implemented built-in tests to cover the new/changed code.

## Code style

- [ ] I wrote a self-explanatory code about what it does.
- [ ] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

N/A
# Additional Checks
- [ ] In the case of complex code, I wrote comments to explain it.
- [ ] When possible, I prepared ways to observe the implemented system (logs, data, etc.).
- [ ] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)
